### PR TITLE
Show links for crate now that it's published

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# Keep a Changelog File
-
-[![Build Status]][ci] [![MSRV]][install-rust]
+# Keep a Changelog File &emsp; [![Build Status]][ci] [![Docs]][docs.rs] [![Latest Version]][crates.io] [![MSRV]][install-rust]
 
 A serializer and deserializer for changelog files written in [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 format.
@@ -14,7 +12,13 @@ cargo add keep_a_changelog_file
 ## Usage
 
 ```rust
-use keep_a_changelog_file::{Changelog, ChangeGroup, PromoteOptions, ReleaseLink, ReleaseVersion};
+use keep_a_changelog_file::{
+    Changelog,
+    ChangeGroup,
+    PromoteOptions,
+    ReleaseLink,
+    ReleaseVersion
+};
 
 fn example_usage() {
     // parse a changelog
@@ -53,9 +57,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 }
 ```
 
-[Build Status]: https://img.shields.io/github/actions/workflow/status/heroku/keep_a_changelog/ci.yml?branch=main
+[Build Status]: https://img.shields.io/github/actions/workflow/status/heroku/keep_a_changelog_file/ci.yml?branch=main
 
-[ci]: https://github.com/heroku/keep_a_changelog/actions/workflows/ci.yml?query=branch%3Amain
+[ci]: https://github.com/heroku/keep_a_changelog_file/actions/workflows/ci.yml?query=branch%3Amain
 
 [MSRV]: https://img.shields.io/badge/MSRV-rustc_1.74+-lightgray.svg
 
@@ -63,7 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Docs]: https://img.shields.io/docsrs/keep_a_changelog_file
 
-[docs.rs]: https://docs.rs/keep_a_changelog/latest/keep_a_changelog_file/
+[docs.rs]: https://docs.rs/keep_a_changelog_file/latest/keep_a_changelog_file/
 
 [Latest Version]: https://img.shields.io/crates/v/keep_a_changelog_file.svg
 


### PR DESCRIPTION
Now that the library is published, the README links go to the correct location so they can be shown.

Also renamed this repo from `keep_a_changelog` to `keep_a_changelog_file` to be consistent with the rest of the naming.