### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-#ECCN:Open Source 5D002
+#ECCN:Open Source
 * @colincasey


### PR DESCRIPTION
Fixing invalid ECCN tag
GUS: [W-18895932](https://gus.lightning.force.com/a07EE00002GtnYYYAZ)