### PR TITLE
Fix clippy useless_conversion lint

### DIFF
--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -361,7 +361,7 @@ fn parse_changelog(input: &str) -> Result<Changelog, ParseChangelogErrorInternal
                 match release_entry_type {
                     ReleaseHeaderType::Unreleased => {
                         unreleased = Some(Unreleased {
-                            changes: Changes::from_iter(changes.into_iter()),
+                            changes: Changes::from_iter(changes),
                             link: None,
                         });
                     }
@@ -373,7 +373,7 @@ fn parse_changelog(input: &str) -> Result<Changelog, ParseChangelogErrorInternal
                                 date,
                                 tag,
                                 link: None,
-                                changes: Changes::from_iter(changes.into_iter()),
+                                changes: Changes::from_iter(changes),
                             },
                         );
                     }


### PR DESCRIPTION
Rust 1.96.1's clippy tightened the useless_conversion lint, which now flags the redundant `.into_iter()` calls passed to `Changes::from_iter` (which already accepts any `IntoIterator`). Remove them so CI lint passes.

This was failing the `Lint` check on `main`, which also blocks Dependabot PR #28.

GUS-W-23269826.